### PR TITLE
docs: add project tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+> **gamez** — a collection of browser-based games built with Next.js.
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
Adds a brief tagline to the README intro to give the project more context.